### PR TITLE
enable autoreconnect

### DIFF
--- a/ESP_ATMod/ESP_ATMod.ino
+++ b/ESP_ATMod/ESP_ATMod.ino
@@ -183,7 +183,7 @@ void setup()
 	// Set the WiFi defaults
 	WiFi.mode(WIFI_STA);
 	WiFi.persistent(false);
-	WiFi.setAutoReconnect(false);
+	WiFi.setAutoReconnect(true);
 
 	// Set the SNTP defaults
 	gsSNTPServer[0] = "pool.ntp.org";


### PR DESCRIPTION
standard AT firmware 1.7+ does automatically reconnect when AP is available again