### PR TITLE
fix AT+CIPSTATUS to list SoftAP TCP connections

### DIFF
--- a/ESP_ATMod/ESP_ATMod.ino
+++ b/ESP_ATMod/ESP_ATMod.ino
@@ -47,6 +47,7 @@
  * 0.3.6a: Fixed long hostname in AT+CIPSTART, input buffer and string search increased to 200 characters
  * 0.3.6b: Checking the appropriate mode for some commands [J.A]
  * 0.4.0: Arduino ESP8266 Core 3.1.1 
+ * 0.4.0a: AT+CIPSTATUS lists SoftAP TCP connections [J.A]
  *
  * TODO:
  * - Implement AP mode DHCP settings and AT+CWLIF
@@ -79,7 +80,7 @@ extern "C"
  * Defines
  */
 
-const char APP_VERSION[] = "0.4.0";
+const char APP_VERSION[] = "0.4.0a";
 
 /*
  * Constants

--- a/ESP_ATMod/command.cpp
+++ b/ESP_ATMod/command.cpp
@@ -1503,41 +1503,41 @@ void cmd_AT_CIPSTATUS()
 		Serial.println(F("STATUS:5"));
 		statusPrinted = true;
 	}
-//	else  <-- no else. we have to list SoftAP TCP connections too
+	
+	//	We have to list SoftAP TCP connections, too
+	uint8_t maxCli = 0; // Maximum client number
+	if (gsCipMux == 1)
+		maxCli = 4;
+
+	for (uint8_t i = 0; i <= maxCli; ++i)
 	{
-		uint8_t maxCli = 0; // Maximum client number
-		if (gsCipMux == 1)
-			maxCli = 4;
-
-		for (uint8_t i = 0; i <= maxCli; ++i)
+		WiFiClient *cli = clients[i].client;
+		if (cli != nullptr && cli->connected())
 		{
-			WiFiClient *cli = clients[i].client;
-			if (cli != nullptr && cli->connected())
+			if (!statusPrinted)
 			{
-				if (!statusPrinted)
-				{
-					Serial.println(F("STATUS:3"));
-					statusPrinted = true;
-				}
-
-				const char types_text[3][4] = {"TCP", "UDP", "SSL"};
-				Serial.printf_P(PSTR("+CIPSTATUS:%d,\"%s\",\"%s\",%d,%d,0\r\n"), i, types_text[clients[i].type],
-								cli->remoteIP().toString().c_str(), cli->remotePort(), cli->localPort());
+				Serial.println(F("STATUS:3"));
+				statusPrinted = true;
 			}
-		}
 
-		if (!statusPrinted)
-		{
-			char stat;
-
-			if (gsWasConnected)
-				stat = '4';
-			else
-				stat = '2';
-
-			Serial.printf_P(PSTR("STATUS:%c\r\n"), stat);
+			const char types_text[3][4] = {"TCP", "UDP", "SSL"};
+			Serial.printf_P(PSTR("+CIPSTATUS:%d,\"%s\",\"%s\",%d,%d,0\r\n"), i, types_text[clients[i].type],
+							cli->remoteIP().toString().c_str(), cli->remotePort(), cli->localPort());
 		}
 	}
+
+	if (!statusPrinted)
+	{
+		char stat;
+
+		if (gsWasConnected)
+			stat = '4';
+		else
+			stat = '2';
+
+		Serial.printf_P(PSTR("STATUS:%c\r\n"), stat);
+	}
+
 	Serial.printf_P(MSG_OK);
 }
 

--- a/ESP_ATMod/command.cpp
+++ b/ESP_ATMod/command.cpp
@@ -1489,15 +1489,22 @@ void cmd_AT_CWHOSTNAME()
  */
 void cmd_AT_CIPSTATUS()
 {
+	/* Early AT firmware versions could do only STA and one TCP connection, but now with SoftAP
+	 * and multiple connections support the STA status and the list of TCP connections are two
+	 * independent informations. It is not possible to know which of the TCP connections use STA
+	 * so the STA statuses 3 and 4 can't be evaluated for STA only.
+	 */
+
 	wl_status_t status = WiFi.status();
+	bool statusPrinted = false;
 
 	if (status != WL_CONNECTED)
 	{
-		Serial.println(F("STATUS:5\r\n\r\nOK"));
+		Serial.println(F("STATUS:5"));
+		statusPrinted = true;
 	}
-	else
+//	else  <-- no else. we have to list SoftAP TCP connections too
 	{
-		bool statusPrinted = false;
 		uint8_t maxCli = 0; // Maximum client number
 		if (gsCipMux == 1)
 			maxCli = 4;
@@ -1530,9 +1537,8 @@ void cmd_AT_CIPSTATUS()
 
 			Serial.printf_P(PSTR("STATUS:%c\r\n"), stat);
 		}
-
-		Serial.printf_P(MSG_OK);
 	}
+	Serial.printf_P(MSG_OK);
 }
 
 /*


### PR DESCRIPTION
Early AT firmware versions could do only STA and one TCP connection, but now with SoftAP and multiple connections support the STA status and the list of TCP connections are two independent information and the standard AT firmware lists SoftAP connections even if STA is disconnected.